### PR TITLE
Increased filesystem buffer size

### DIFF
--- a/src/cultures/fs.ts
+++ b/src/cultures/fs.ts
@@ -90,7 +90,7 @@ function getFiles(n: number, view: SequentialDataView): FileInfo[] {
 }
 
 export async function load_fs(datafile: File): Promise<CulturesFS> {
-  const buffer = await read_file(datafile.slice(0, 200 * 1024));
+  const buffer = await read_file(datafile.slice(0, 250 * 1024));
   const view = new SequentialDataView(buffer);
 
   const header = getHeader(view);


### PR DESCRIPTION
When attempting to load `DataX/Libs/data0001.lib` from a **Cultures - 8th Wonder of the World**  (v1.00, Nov 29, 2003 17:37:35) we receive the following error message:

<img width="696" alt="2020-12-27 um 01 11 44" src="https://user-images.githubusercontent.com/5388534/103161336-8f752e80-47e0-11eb-8093-a71f6cf99b48.png">

```
Uncaught (in promise) RangeError: offset is outside the bounds of the DataView
    getUint32 webpack:///./src/utils/dataview.ts?:47
    getFiles webpack:///./src/cultures/fs.ts?:56
    load_fs webpack:///./src/cultures/fs.ts?:67
    load_object_file webpack:///./src/view/App/App.tsx?:19
    onDrop webpack:///./src/view/App/App.tsx?:30
    onDrop webpack:///./src/view/App/App.tsx?:41
    React 17
    unstable_runWithPriority webpack:///./node_modules/scheduler/cjs/scheduler.development.js?:653
    React 4
```

This increases the buffer slice size so we can properly parse the fs.